### PR TITLE
Errors on Custom Post request

### DIFF
--- a/octoprint_shutdownprinter/__init__.py
+++ b/octoprint_shutdownprinter/__init__.py
@@ -50,6 +50,7 @@ class shutdownprinterPlugin(octoprint.plugin.SettingsPlugin,
 		self.api_plugin_port = 5000
 		self.extraCommand = ""
 		self.abortTimeout = 0
+		self.forcedAbort = False
 		self.temperatureValue = 0
 		self.temperatureTarget = False
 		self.printFailed = False
@@ -534,7 +535,7 @@ class shutdownprinterPlugin(octoprint.plugin.SettingsPlugin,
 				self._logger.error("Failed to connect to call api: %s" % e.message)
 				return
 		if self.api_custom_POST == True:
-			data = self.api_custom_body
+			data = self.api_custom_body.encode()
 			self._logger.info("Shutting down printer with API custom (POST)")
 			try:
 				request = urllib2.Request(self.api_custom_url, data=data, headers=headers)


### PR DESCRIPTION
It seemed that the default attribute was missing, crashing the script. Also the Post request needs to be encoded to byte to work correctly.